### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/infradeploy.yml
+++ b/.github/workflows/infradeploy.yml
@@ -20,7 +20,7 @@ jobs:
     #    with:
     #     inlineScript: |
     #        aadSid=$(az ad user show --id ${{ secrets.AAD_USERNAME }} --query objectId -o tsv)
-    #        echo "::set-output name=aadSid::$aadSid"
+    #        echo "aadSid=$aadSid" >> "$GITHUB_OUTPUT"
      - uses: azure/arm-deploy@v1
        id: deploy
        name: Deploy Bicep


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `::set-output` to `"$GITHUB_OUTPUT"`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter